### PR TITLE
Implement Bencode Parser and Tracker Communication

### DIFF
--- a/cmd/gottrent/main.go
+++ b/cmd/gottrent/main.go
@@ -1,7 +1,79 @@
 package main
 
-import "fmt"
+import (
+	"flag" // For parsing command-line arguments
+	"fmt"
+	"log" // For fatal errors
+
+	"github.com/Oblutack/GoTorrent/internal/metainfo" // Import our metainfo package
+)
 
 func main() {
-	fmt.Println("GoTorrent CLI - Uskoro!")
+	// Define a string flag for the torrent file path
+	// -torrent <path>
+	torrentFilePath := flag.String("torrent", "", "Path to the .torrent file")
+	flag.Parse() // Parse the command-line flags
+
+	if *torrentFilePath == "" {
+		log.Println("Usage: gottrent -torrent <path_to_torrent_file>")
+		flag.PrintDefaults() // Print default usage information
+		return
+	}
+
+	log.Printf("Loading torrent file: %s\n", *torrentFilePath)
+
+	metaInfo, err := metainfo.LoadFromFile(*torrentFilePath)
+	if err != nil {
+		log.Fatalf("Error loading torrent file: %v\n", err)
+	}
+
+	// Print some basic information from the parsed MetaInfo
+	fmt.Println("-----------------------------------------------------")
+	fmt.Println("Torrent MetaInfo:")
+	fmt.Println("-----------------------------------------------------")
+	fmt.Printf("Announce URL: %s\n", metaInfo.Announce)
+
+	if len(metaInfo.AnnounceList) > 0 {
+		fmt.Println("Announce List:")
+		for i, tier := range metaInfo.AnnounceList {
+			fmt.Printf("  Tier %d:\n", i+1)
+			for _, trackerURL := range tier {
+				fmt.Printf("    - %s\n", trackerURL)
+			}
+		}
+	}
+
+	if metaInfo.Comment != "" {
+		fmt.Printf("Comment: %s\n", metaInfo.Comment)
+	}
+	if metaInfo.CreatedBy != "" {
+		fmt.Printf("Created By: %s\n", metaInfo.CreatedBy)
+	}
+	if metaInfo.CreationDate > 0 {
+		// TODO: Format timestamp to human-readable date
+		fmt.Printf("Creation Date (Unix): %d\n", metaInfo.CreationDate)
+	}
+
+	// InfoHash is currently all zeros, but let's print it anyway
+	fmt.Printf("InfoHash (hex): %x\n", metaInfo.InfoHash) // %x for hex representation of byte array
+
+	fmt.Printf("Torrent Name: %s\n", metaInfo.Info.Name)
+	fmt.Printf("Piece Length: %d bytes\n", metaInfo.Info.PieceLength)
+	fmt.Printf("Total Length: %d bytes\n", metaInfo.TotalLength)
+	fmt.Printf("Number of Pieces: %d\n", len(metaInfo.PieceHashes))
+	if metaInfo.Info.Private == 1 {
+		fmt.Println("Private Torrent: Yes")
+	}
+
+	if len(metaInfo.Info.Files) > 0 {
+		fmt.Println("Files:")
+		for i, file := range metaInfo.Info.Files {
+			fmt.Printf("  %d. Path: %s, Length: %d bytes\n", i+1, file.Path, file.Length) // TODO: Join file.Path
+		}
+	} else {
+		fmt.Printf("Single File Length: %d bytes\n", metaInfo.Info.Length)
+	}
+	fmt.Println("-----------------------------------------------------")
+
+	// TODO: Further steps - connect to tracker, peers, etc.
 }

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,3 @@ module github.com/Oblutack/GoTorrent
 
 go 1.24.0
 
-require github.com/jackpal/bencode-go v1.0.2

--- a/internal/gobencode/decode.go
+++ b/internal/gobencode/decode.go
@@ -1,0 +1,260 @@
+// Package gobencode implements encoding and decoding of Bencode data.
+package gobencode // Promenili smo ime paketa
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+)
+
+// ErrMalformedData is returned when the bencoded data is not in the correct format.
+var ErrMalformedData = errors.New("gobencode: malformed data") // Promenili smo ime u poruci
+
+
+// Decode parses bencoded data from the reader and returns its Go representation.
+// The returned interface{} will be one of:
+// int64, string, []interface{}, map[string]interface{}
+func Decode(r io.Reader) (interface{}, error) {
+	br, ok := r.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(r)
+	}
+	return decodeRecursive(br)
+}
+
+// decodeRecursive is the internal recursive decoding function.
+func decodeRecursive(br *bufio.Reader) (interface{}, error) {
+	firstByte, err := br.ReadByte()
+	if err != nil {
+		if err == io.EOF {
+			// Ako je EOF na samom početku čitanja vrednosti, to je malformed.
+			// Ako je EOF unutar npr. liste nakon nekoliko elemenata, to će obraditi parseList.
+			return nil, fmt.Errorf("%w: unexpected EOF while expecting a value", ErrMalformedData)
+		}
+		return nil, err // Other I/O error
+	}
+
+	switch {
+	case firstByte == 'i':
+		return parseInteger(br)
+	case firstByte == 'l':
+		return parseList(br) 
+		return nil, fmt.Errorf("gobencode: list parsing not yet implemented")
+	case firstByte == 'd':
+		return parseDictionary(br) 
+		return nil, fmt.Errorf("gobencode: dictionary parsing not yet implemented")
+	case firstByte >= '0' && firstByte <= '9':
+		if err := br.UnreadByte(); err != nil { // Put the first byte back
+			return nil, err
+		}
+		return parseString(br)
+	default:
+		return nil, fmt.Errorf("%w: unexpected token '%c' (0x%x) at start of value", ErrMalformedData, firstByte, firstByte)
+	}
+}
+
+// parseInteger parses a bencoded integer from the reader.
+// It assumes the initial 'i' has already been consumed.
+func parseInteger(br *bufio.Reader) (int64, error) {
+	var numBytes []byte
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return 0, fmt.Errorf("%w: unexpected EOF while parsing integer", ErrMalformedData)
+			}
+			return 0, err
+		}
+
+		if b == 'e' { // End of integer
+			if len(numBytes) == 0 {
+				return 0, fmt.Errorf("%w: integer 'ie' is invalid", ErrMalformedData)
+			}
+			break
+		}
+		numBytes = append(numBytes, b)
+	}
+
+	numStr := string(numBytes)
+
+	// Validate integer format:
+	// - "i-0e" is invalid
+	// - "i03e" is invalid (leading zeros for non-zero numbers)
+	// - "i0e" is valid
+	if len(numStr) > 1 && numStr[0] == '0' {
+		return 0, fmt.Errorf("%w: invalid integer format (leading zero for non-zero number '%s')", ErrMalformedData, numStr)
+	}
+	if len(numStr) > 2 && numStr[0] == '-' && numStr[1] == '0' {
+		return 0, fmt.Errorf("%w: invalid integer format (leading zero for negative number '%s')", ErrMalformedData, numStr)
+	}
+    if numStr == "-" { // "i-e"
+        return 0, fmt.Errorf("%w: invalid integer format (just a hyphen)", ErrMalformedData)
+    }
+
+
+	val, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("%w: could not parse integer string '%s': %v", ErrMalformedData, numStr, err)
+	}
+	return val, nil
+}
+
+// parseString parses a bencoded string from the reader.
+// It assumes the first digit of the length has already been peeked (and unread).
+func parseString(br *bufio.Reader) (string, error) {
+	var lenBytes []byte
+	for {
+		b, err := br.ReadByte()
+		if err != nil {
+			if err == io.EOF {
+				return "", fmt.Errorf("%w: unexpected EOF while parsing string length", ErrMalformedData)
+			}
+			return "", err
+		}
+
+		if b == ':' {
+			if len(lenBytes) == 0 {
+				return "", fmt.Errorf("%w: string length delimiter ':' found without preceding digits", ErrMalformedData)
+			}
+			break
+		}
+
+		if b < '0' || b > '9' {
+			return "", fmt.Errorf("%w: non-digit character '%c' found in string length", ErrMalformedData, b)
+		}
+		lenBytes = append(lenBytes, b)
+	}
+
+	// Bencode spec disallows leading zeros in string length, unless the length is 0 itself.
+	if len(lenBytes) > 1 && lenBytes[0] == '0' {
+		return "", fmt.Errorf("%w: string length has leading zero ('%s')", ErrMalformedData, string(lenBytes))
+	}
+
+
+	length, err := strconv.ParseInt(string(lenBytes), 10, 64)
+	if err != nil {
+		// This should ideally not happen if previous checks are correct, but as a safeguard:
+		return "", fmt.Errorf("%w: could not parse string length '%s': %v", ErrMalformedData, string(lenBytes), err)
+	}
+
+	if length < 0 {
+		// Theoretical, as ParseInt above with base 10 on digits '0'-'9' won't produce negative.
+		// But good for completeness if the spec allowed negative lengths (it doesn't).
+		return "", fmt.Errorf("%w: negative string length (%d) is invalid", ErrMalformedData, length)
+	}
+    
+    // Zaštita od ekstremno velikih dužina stringova koje bi mogle da izazovu DoS
+    // Možeš podesiti ovaj limit po potrebi. 1GB je verovatno previše za torrent metainfo.
+    const maxStringLength = 64 * 1024 * 1024 // 64 MB
+    if length > maxStringLength {
+        return "", fmt.Errorf("%w: string length %d exceeds maximum allowed %d", ErrMalformedData, length, maxStringLength)
+    }
+
+
+	strBytes := make([]byte, length)
+	n, err := io.ReadFull(br, strBytes)
+	if err != nil {
+		if err == io.EOF || err == io.ErrUnexpectedEOF {
+			return "", fmt.Errorf("%w: unexpected EOF while reading string content (expected %d bytes, got %d)", ErrMalformedData, length, n)
+		}
+		return "", err // Other I/O error
+	}
+
+	return string(strBytes), nil
+}
+
+func parseList(br *bufio.Reader) ([]interface{}, error) {
+	list := make([]interface{}, 0)
+	for {
+		// Peek at the next byte to check for the end-of-list marker 'e'
+		// without consuming it yet.
+		firstByte, err := br.Peek(1)
+		if err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("%w: unexpected EOF while expecting list element or 'e'", ErrMalformedData)
+			}
+			return nil, err // Other I/O error
+		}
+
+		if firstByte[0] == 'e' {
+			_, err = br.ReadByte() // Consume the 'e'
+			if err != nil {        // Should not happen if Peek succeeded, but good practice
+				return nil, err
+			}
+			break // End of list
+		}
+
+		// If not 'e', then it must be an element.
+		// Decode the element recursively.
+		element, err := decodeRecursive(br) // Ključno: rekurzivni poziv
+		if err != nil {
+			// Greška iz rekurzivnog poziva će već biti formatirana,
+			// ali možemo dodati kontekst da je nastala unutar liste.
+			return nil, fmt.Errorf("gobencode: error parsing list element: %w", err)
+		}
+		list = append(list, element)
+	}
+	return list, nil
+}
+
+func parseDictionary(br *bufio.Reader) (map[string]interface{}, error) {
+	dict := make(map[string]interface{})
+	var lastKey string // For checking lexicographical order (optional for decoder robustness)
+	firstKeyProcessed := false
+
+	for {
+		// Peek at the next byte for 'e' or a key (which must be a string)
+		firstByte, err := br.Peek(1)
+		if err != nil {
+			if err == io.EOF {
+				return nil, fmt.Errorf("%w: unexpected EOF while expecting dict key or 'e'", ErrMalformedData)
+			}
+			return nil, err
+		}
+
+		if firstByte[0] == 'e' {
+			_, err = br.ReadByte() // Consume 'e'
+			if err != nil {
+				return nil, err
+			}
+			break // End of dictionary
+		}
+
+		// Keys in a bencoded dictionary MUST be strings.
+		// We can call parseString directly here, but parseString expects
+		// the first digit to be unread. So, we'll call decodeRecursive
+		// and then type-assert.
+		keyInterface, err := decodeRecursive(br) // Parsiraj ključ
+		if err != nil {
+			return nil, fmt.Errorf("gobencode: error parsing dictionary key: %w", err)
+		}
+
+		key, ok := keyInterface.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: dictionary key is not a string (got %T)", ErrMalformedData, keyInterface)
+		}
+
+		// Optional: Check if keys are in lexicographical order
+		if firstKeyProcessed && key <= lastKey {
+			// The spec requires keys to be sorted. Some decoders are lenient.
+			// For robustness, we might choose to error out or just log a warning.
+			// For now, let's be strict as per spec.
+			return nil, fmt.Errorf("%w: dictionary keys not in lexicographical order ('%s' after '%s')", ErrMalformedData, key, lastKey)
+		}
+		lastKey = key
+		firstKeyProcessed = true
+
+
+		// Parse the value associated with the key
+		value, err := decodeRecursive(br) // Parsiraj vrednost
+		if err != nil {
+			return nil, fmt.Errorf("gobencode: error parsing dictionary value for key '%s': %w", key, err)
+		}
+
+		dict[key] = value
+	}
+	return dict, nil
+}
+

--- a/internal/gobencode/decode_test.go
+++ b/internal/gobencode/decode_test.go
@@ -1,0 +1,229 @@
+package gobencode // Must be the same package name for testing unexported functions if needed,
+// or gobencode_test if testing only exported functions (Decode).
+// Let's use 'package gobencode' for now as our parse* functions are not exported.
+
+import (
+	"errors"
+	"io"
+	"reflect" // For DeepEqual
+	"strings"
+	"testing"
+)
+
+func TestDecode(t *testing.T) {
+	testCases := []struct {
+		name    string      // Name of the test case
+		input   string      // Bencoded input string
+		want    interface{} // Expected Go value
+		wantErr error       // Expected error (nil if no error)
+	}{
+		// --- Integer Test Cases ---
+		{
+			name:  "integer zero",
+			input: "i0e",
+			want:  int64(0),
+		},
+		{
+			name:  "positive integer",
+			input: "i42e",
+			want:  int64(42),
+		},
+		{
+			name:  "negative integer",
+			input: "i-42e",
+			want:  int64(-42),
+		},
+		{
+			name:    "invalid integer - empty",
+			input:   "ie",
+			wantErr: ErrMalformedData, // Or a more specific error if you wrap it
+		},
+		{
+			name:    "invalid integer - leading zero positive",
+			input:   "i042e",
+			wantErr: ErrMalformedData,
+		},
+		{
+			name:    "invalid integer - leading zero negative",
+			input:   "i-042e",
+			wantErr: ErrMalformedData,
+		},
+		{
+			name:    "invalid integer - missing e",
+			input:   "i42",
+			wantErr: ErrMalformedData, // Will likely be an EOF error wrapped by ErrMalformedData
+		},
+		{
+			name:    "invalid integer - non-digit",
+			input:   "i42xe",
+			wantErr: ErrMalformedData,
+		},
+        {
+            name:    "invalid integer - just hyphen",
+            input:   "i-e",
+            wantErr: ErrMalformedData,
+        },
+
+
+		// --- String Test Cases ---
+		{
+			name:  "empty string",
+			input: "0:",
+			want:  "",
+		},
+		{
+			name:  "simple string",
+			input: "4:spam",
+			want:  "spam",
+		},
+		{
+			name:    "string missing colon",
+			input:   "4spam",
+			wantErr: ErrMalformedData,
+		},
+		{
+			name:    "string length too short",
+			input:   "10:spam", // claims 10 bytes, provides 4
+			wantErr: ErrMalformedData, // Will be EOF wrapped
+		},
+		{
+			name:    "string length not a number",
+			input:   "spam:spam",
+			wantErr: ErrMalformedData,
+		},
+		{
+			name:    "string length has leading zero",
+			input:   "04:spam",
+			wantErr: ErrMalformedData,
+		},
+		// TODO: Add more test cases for strings
+
+		// --- List Test Cases ---
+		{
+			name:  "empty list",
+			input: "le",
+			want:  make([]interface{}, 0),
+		},
+		{
+			name:  "list of integers",
+			input: "li1ei2ei3ee",
+			want:  []interface{}{int64(1), int64(2), int64(3)},
+		},
+		{
+			name:  "list of mixed types",
+			input: "li42e4:spame", // [42, "spam"]
+			want:  []interface{}{int64(42), "spam"},
+		},
+		{
+			name:  "nested list",
+			input: "lli1ei2ee4:spame", // [[1, 2], "spam"]
+			want:  []interface{}{[]interface{}{int64(1), int64(2)}, "spam"},
+		},
+		{
+			name:    "list missing e",
+			input:   "li1e",
+			wantErr: ErrMalformedData, // EOF wrapped
+		},
+		// TODO: Add more test cases for lists
+
+
+		// --- Dictionary Test Cases ---
+		{
+			name:  "empty dictionary",
+			input: "de",
+			want:  map[string]interface{}{},
+		},
+		{
+			name:  "simple dictionary",
+			input: "d3:key5:valuee",
+			want:  map[string]interface{}{"key": "value"},
+		},
+		{
+			name:  "dictionary with integer value",
+			input: "d3:numi42ee",
+			want:  map[string]interface{}{"num": int64(42)},
+		},
+		{
+			name:  "dictionary with list value",
+			input: "d4:listli1ei2eee",
+			want:  map[string]interface{}{"list": []interface{}{int64(1), int64(2)}},
+		},
+		{
+			name: "nested dictionary",
+			input: "d5:outerd3:key5:valueee", // {"outer": {"key": "value"}}
+			want: map[string]interface{}{
+				"outer": map[string]interface{}{"key": "value"},
+			},
+		},
+		{
+			name:    "dictionary missing value",
+			input:   "d3:keye",
+			wantErr: ErrMalformedData, // EOF or other error wrapped
+		},
+		{
+			name:    "dictionary key not a string",
+			input:   "di1e5:valuee",
+			wantErr: ErrMalformedData,
+		},
+		{
+			name:    "dictionary keys not sorted",
+			input:   "d1:B1:b1:A1:ae", // B comes after A
+			wantErr: ErrMalformedData,
+		},
+        {
+            name: "dictionary with multiple keys sorted",
+            input: "d1:A1:a1:B1:be",
+            want: map[string]interface{}{"A": "a", "B": "b"},
+        },
+		// TODO: Add more test cases for dictionaries
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := strings.NewReader(tc.input)
+			got, err := Decode(r) // Call our main Decode function
+
+			// Check error
+			if tc.wantErr != nil {
+				if err == nil {
+					t.Errorf("Decode() error = nil, wantErr %v", tc.wantErr)
+					return
+				}
+				// We might want to check if the error *is* or *wraps* tc.wantErr
+				// For simplicity now, we'll just check if an error was expected and one occurred.
+				// A more robust check: if !errors.Is(err, tc.wantErr) { ... }
+                // Or check the error message string if specific.
+                // For now, let's assume any error is fine if one was expected, or check if it IS ErrMalformedData
+				if !errors.Is(err, tc.wantErr) && tc.wantErr == ErrMalformedData {
+					// If we expect ErrMalformedData, let's be a bit more specific
+					// This helps catch cases where we get an unexpected I/O error instead of a parsing error
+					t.Errorf("Decode() error = %v, wantErr to be or wrap %v", err, tc.wantErr)
+				}
+                // If tc.wantErr is not ErrMalformedData, it might be a generic io.EOF for example.
+                // For now, just checking if err != nil is enough if tc.wantErr is not nil.
+			} else if err != nil {
+				t.Errorf("Decode() unexpected error = %v", err)
+				return
+			}
+
+			// Check value if no error was expected
+			if tc.wantErr == nil && !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("Decode() got = %v (%T), want %v (%T)", got, got, tc.want, tc.want)
+			}
+
+            // Check if all input was consumed for successful decodes
+            // If there's leftover data, it might indicate a parsing bug.
+            if err == nil {
+                var remainingByte [1]byte
+                n, readErr := r.Read(remainingByte[:])
+                if n > 0 {
+                    t.Errorf("Decode() left unconsumed data: '%c'", remainingByte[0])
+                } else if readErr != io.EOF && readErr != nil {
+                    // This case is less likely if Decode itself didn't error,
+                    // but good to be aware of.
+                    t.Errorf("Decode() error reading for leftover data: %v", readErr)
+                }
+            }
+		})
+	}
+}

--- a/internal/gobencode/encode.go
+++ b/internal/gobencode/encode.go
@@ -1,0 +1,166 @@
+package gobencode
+
+import (
+	"bufio" // For potentially buffered writing
+	"fmt"
+	"io"
+	"reflect" // To inspect the type of the data
+	"sort"    // For sorting dictionary keys
+	"strconv"
+)
+
+// Encode writes the Bencode encoding of data to the writer w.
+// Supported Go types for data:
+// int, int8, int16, int32, int64
+// uint, uint8, uint16, uint32, uint64 (treated as int64, check for overflow if necessary or restrict)
+// string
+// []interface{} (slice of interface{})
+// map[string]interface{}
+//
+// For slices and maps, their elements must also be of supported types.
+func Encode(w io.Writer, data interface{}) error {
+	// It's often good to use a buffered writer for efficiency,
+	// especially if the underlying writer is not buffered (e.g., a network connection).
+	// However, for simplicity in this first pass, we can write directly to w.
+	// If w is already a *bufio.Writer, that's even better.
+	// Let's assume w might not be buffered.
+	bw, ok := w.(*bufio.Writer)
+	if !ok {
+		bw = bufio.NewWriter(w)
+		// We must ensure the buffer is flushed at the end if we created it.
+		defer bw.Flush()
+	}
+
+	return encodeRecursive(bw, data)
+}
+
+// encodeRecursive is the internal recursive encoding function.
+func encodeRecursive(w *bufio.Writer, data interface{}) error {
+	if data == nil {
+		// How to encode nil? Bencode doesn't have a nil type.
+		// Often, nil slices/maps are encoded as empty lists/dictionaries.
+		// A nil string could be an empty string. A nil int is problematic.
+		// For now, let's return an error or encode as an empty string (common for optional fields).
+		// Or, we can decide based on context (e.g. omitempty in struct tags).
+		// Let's try to encode as an empty string, as some bencode implementations might expect something.
+		// Or better yet, let the caller handle nils if they mean "omit".
+		// Let's return an error for a direct nil.
+		return fmt.Errorf("gobencode: cannot encode nil value directly")
+	}
+
+	switch v := data.(type) {
+	case string:
+		return encodeString(w, v)
+	case int:
+		return encodeInteger(w, int64(v))
+	case int8:
+		return encodeInteger(w, int64(v))
+	case int16:
+		return encodeInteger(w, int64(v))
+	case int32:
+		return encodeInteger(w, int64(v))
+	case int64:
+		return encodeInteger(w, v)
+	// For unsigned integers, Bencode spec implies integers.
+	// We'll cast them to int64. Be mindful of potential overflow if uint64 > MaxInt64.
+	// For .torrent files, this is usually not an issue as numbers are within int64 range.
+	case uint:
+		return encodeInteger(w, int64(v))
+	case uint8:
+		return encodeInteger(w, int64(v))
+	case uint16:
+		return encodeInteger(w, int64(v))
+	case uint32:
+		return encodeInteger(w, int64(v))
+	case uint64:
+        // Handle potential overflow for uint64 -> int64
+        if v > uint64(9223372036854775807) { // MaxInt64
+            return fmt.Errorf("gobencode: uint64 value %d overflows int64", v)
+        }
+		return encodeInteger(w, int64(v))
+	case []interface{}:
+		return encodeList(w, v)
+	case map[string]interface{}:
+		return encodeDictionary(w, v)
+	default:
+		// For other types, we could use reflect, but it gets more complex.
+		// For now, let's restrict to the types above.
+		// Using reflect.Value:
+		val := reflect.ValueOf(data)
+		switch val.Kind() {
+		case reflect.Slice:
+			// Need to convert val (reflect.Value) to []interface{}
+			// This is tricky if it's not already []interface{}.
+			// For now, we'll only support []interface{} directly via type assertion.
+			return fmt.Errorf("gobencode: unsupported slice type %T, only []interface{} is supported directly", data)
+		case reflect.Map:
+			// Similar to slices, direct support for map[string]interface{} is easier.
+			// We'd need to check if key is string.
+			return fmt.Errorf("gobencode: unsupported map type %T, only map[string]interface{} is supported directly", data)
+		}
+		return fmt.Errorf("gobencode: unsupported type %T for encoding", data)
+	}
+}
+
+func encodeInteger(w *bufio.Writer, val int64) error {
+	// Write 'i', then the integer, then 'e'
+	if err := w.WriteByte('i'); err != nil {
+		return err
+	}
+	// strconv.FormatInt converts int64 to its string representation in base 10
+	if _, err := w.WriteString(strconv.FormatInt(val, 10)); err != nil {
+		return err
+	}
+	return w.WriteByte('e')
+}
+
+func encodeString(w *bufio.Writer, val string) error {
+	// Write length, then ':', then the string
+	// strconv.Itoa converts int to string. len(val) returns int.
+	if _, err := w.WriteString(strconv.Itoa(len(val))); err != nil {
+		return err
+	}
+	if err := w.WriteByte(':'); err != nil {
+		return err
+	}
+	_, err := w.WriteString(val)
+	return err
+}
+
+func encodeList(w *bufio.Writer, list []interface{}) error {
+	if err := w.WriteByte('l'); err != nil {
+		return err
+	}
+	for _, item := range list {
+		if err := encodeRecursive(w, item); err != nil { // Recursive call for each item
+			return err
+		}
+	}
+	return w.WriteByte('e')
+}
+
+func encodeDictionary(w *bufio.Writer, dict map[string]interface{}) error {
+	if err := w.WriteByte('d'); err != nil {
+		return err
+	}
+
+	// Keys in a bencoded dictionary MUST be sorted lexicographically.
+	keys := make([]string, 0, len(dict))
+	for k := range dict {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys) // Sort the keys
+
+	for _, k := range keys {
+		// Encode the key (which must be a string)
+		if err := encodeString(w, k); err != nil {
+			return fmt.Errorf("gobencode: error encoding dictionary key '%s': %w", k, err)
+		}
+		// Encode the value
+		if err := encodeRecursive(w, dict[k]); err != nil { // Recursive call for the value
+			return fmt.Errorf("gobencode: error encoding dictionary value for key '%s': %w", k, err)
+		}
+	}
+
+	return w.WriteByte('e')
+}

--- a/internal/gobencode/encode_test.go
+++ b/internal/gobencode/encode_test.go
@@ -1,0 +1,99 @@
+// In internal/gobencode/encode_test.go
+package gobencode
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestEncode(t *testing.T) {
+	testCases := []struct {
+		name    string
+		input   interface{}
+		want    string
+		wantErr bool
+	}{
+		// Integer tests
+		{"encode integer zero", int64(0), "i0e", false},
+		{"encode positive integer", int64(42), "i42e", false},
+		{"encode negative integer", int64(-42), "i-42e", false},
+		{"encode int type", int(123), "i123e", false},
+
+		// String tests
+		{"encode empty string", "", "0:", false},
+		{"encode simple string", "spam", "4:spam", false},
+		{"encode string with spaces", "hello world", "11:hello world", false},
+
+		// List tests
+		{"encode empty list", []interface{}{}, "le", false},
+		{"encode list of integers", []interface{}{int64(1), int64(2), int64(3)}, "li1ei2ei3ee", false},
+		{"encode list of strings", []interface{}{"a", "b", "c"}, "l1:a1:b1:ce", false},
+		{
+			"encode list of mixed types corrected",
+			[]interface{}{int64(10), "eggs", []interface{}{"nested"}},
+			"li10e4:eggsl6:nestedee",
+			false,
+		},
+
+		// Dictionary tests
+		{"encode empty dictionary", map[string]interface{}{}, "de", false},
+		{
+			"encode simple dictionary",
+			map[string]interface{}{"key": "value"},
+			"d3:key5:valuee",
+			false,
+		},
+		{
+			"encode dictionary sorted keys corrected", // Keys: foo, spam
+			map[string]interface{}{"spam": "eggs", "foo": "bar"},
+			"d3:foo3:bar4:spam4:eggse", // Sorted: foo, then spam
+			false,
+		},
+		{
+			"encode dictionary with int and list", // Keys: a_list, an_int (sorted)
+			map[string]interface{}{
+				"an_int": int64(99),
+				"a_list": []interface{}{"one", int64(2)},
+			},
+			"d6:a_listl3:onei2ee6:an_inti99ee",
+			false,
+		},
+		{
+			"encode nested dictionary", // Outer key: "outer". Inner keys: "inner_key", "num_key" (sorted: inner_key, num_key)
+			map[string]interface{}{
+				"outer": map[string]interface{}{
+					"num_key":   int64(7), // num_key should come after inner_key when sorted if using that order in map literal
+					"inner_key": "inner_value",
+				},
+			},
+			// Expected after sorting inner keys: d9:inner_key11:inner_value7:num_keyi7ee
+			// "d5:outerd9:inner_key11:inner_value7:num_keyi7eee" - Original, possibly wrong order if map literal order matters for my mental model
+			// Let's correct based on alphabetical sort of inner keys: "inner_key", "num_key"
+			"d5:outerd9:inner_key11:inner_value7:num_keyi7eee",
+			false,
+		},
+
+		// Error cases
+		{"encode nil directly", nil, "", true},
+		{"encode unsupported type float", float64(3.14), "", true},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			err := Encode(&buf, tc.input)
+
+			if (err != nil) != tc.wantErr {
+				t.Errorf("Encode() error = %v, wantErr %v", err, tc.wantErr)
+				return
+			}
+
+			if !tc.wantErr {
+				got := buf.String()
+				if got != tc.want {
+					t.Errorf("Encode() got = %q, want %q", got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/metainfo/metainfo.go
+++ b/internal/metainfo/metainfo.go
@@ -1,141 +1,191 @@
+// Package metainfo handles parsing and representation of .torrent file metadata.
 package metainfo
 
 import (
-	"bytes"       // For bencoding the InfoDict to calculate InfoHash
-	"crypto/sha1" // For SHA-1 hashing
-	"errors"      // For creating custom errors
-	"io"          // For reading file content
-	"os"          // For file operations
+	"bytes"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"io"
+	"os" // OTKOMENTARISANO - potrebno za LoadFromFile
 
-	"github.com/jackpal/bencode-go"
+	"github.com/Oblutack/GoTorrent/internal/gobencode"
 )
 
-// LoadFromFile parses a .torrent file from the given path.
+// MetaInfo holds all the data from a .torrent file.
+type MetaInfo struct {
+	Announce     string
+	AnnounceList [][]string
+	Comment      string
+	CreatedBy    string
+	CreationDate int64
+
+	Info InfoDict
+
+	InfoHash    [20]byte
+	PieceHashes [][20]byte
+	TotalLength int64
+}
+
+// InfoDict represents the 'info' dictionary within a .torrent file.
+type InfoDict struct {
+	PieceLength int64
+	Pieces      string
+	Private     int
+	Name        string
+
+	Length int64      `bencode:"length,omitempty"` // Only for single-file
+	Files  []FileInfo `bencode:"files,omitempty"`  // Only for multi-file
+}
+
+// FileInfo describes a single file within a multi-file torrent.
+type FileInfo struct {
+	Length int64
+	Path   []string
+	Md5sum string `bencode:"md5sum,omitempty"`
+}
+
+// LoadFromFile opens and parses a .torrent file from the given path.
 func LoadFromFile(filePath string) (*MetaInfo, error) {
 	file, err := os.Open(filePath)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("metainfo: could not open file %s: %w", filePath, err)
 	}
 	defer file.Close()
 
 	return New(file)
 }
 
-// New parses a .torrent file from an io.Reader (e.g., an opened file).
+// New parses .torrent data from an io.Reader.
 func New(r io.Reader) (*MetaInfo, error) {
-	// The top-level structure of a .torrent file is a bencoded dictionary.
-	// We first parse it into a temporary structure that mirrors MetaInfo
-	// but with Info as a RawMessage to calculate InfoHash before full parsing.
-	var torrentFile struct {
-		Announce     string                `bencode:"announce"`
-		AnnounceList [][]string            `bencode:"announce-list"`
-		Comment      string                `bencode:"comment"`
-		CreatedBy    string                `bencode:"created by"`
-		CreationDate int64                 `bencode:"creation date"`
-		Info         bencode.RawMessage    `bencode:"info"` // Keep 'info' as raw bytes first
+	decodedData, err := gobencode.Decode(r)
+	if err != nil {
+		return nil, fmt.Errorf("metainfo: failed to decode torrent data: %w", err)
 	}
 
-	if err := bencode.Unmarshal(r, &torrentFile); err != nil {
-		return nil, err
+	torrentMap, ok := decodedData.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("metainfo: top-level bencode data is not a dictionary")
 	}
 
-	if torrentFile.Announce == "" {
-		return nil, errors.New("metainfo: announce URL is required")
-	}
-	if len(torrentFile.Info) == 0 {
-		return nil, errors.New("metainfo: info dictionary is missing or empty")
-	}
+	mi := &MetaInfo{} // Greška 'undefined: MetaInfo' bi trebalo da nestane
 
-	mi := &MetaInfo{
-		Announce:     torrentFile.Announce,
-		AnnounceList: torrentFile.AnnounceList,
-		Comment:      torrentFile.Comment,
-		CreatedBy:    torrentFile.CreatedBy,
-		CreationDate: torrentFile.CreationDate,
+	// Populate basic fields
+	if announce, ok := torrentMap["announce"].(string); ok {
+		mi.Announce = announce
+	} else {
+		return nil, errors.New("metainfo: 'announce' URL is missing or not a string")
 	}
-
-	// Calculate InfoHash: SHA-1 hash of the bencoded 'info' dictionary
-	h := sha1.New()
-	h.Write(torrentFile.Info) // torrentFile.Info contains the raw bencoded 'info' part
-	copy(mi.InfoHash[:], h.Sum(nil))
-
-	// Now parse the 'info' dictionary into mi.Info
-	if err := bencode.Unmarshal(bytes.NewReader(torrentFile.Info), &mi.Info); err != nil {
-		return nil, errors.New("metainfo: could not parse info dictionary: " + err.Error())
-	}
-
-	// Validate and process pieces
-	if mi.Info.PieceLength == 0 {
-		return nil, errors.New("metainfo: piece length cannot be zero")
-	}
-	if len(mi.Info.Pieces)%sha1.Size != 0 {
-		return nil, errors.New("metainfo: pieces string length is not a multiple of SHA-1 hash size (20 bytes)")
-	}
-	numPieces := len(mi.Info.Pieces) / sha1.Size
-	mi.PieceHashes = make([][20]byte, numPieces)
-	for i := 0; i < numPieces; i++ {
-		copy(mi.PieceHashes[i][:], []byte(mi.Info.Pieces[i*sha1.Size:(i+1)*sha1.Size]))
-	}
-
-	// Calculate TotalLength
-	if mi.Info.Length > 0 { // Single-file torrent
-		mi.TotalLength = mi.Info.Length
-	} else { // Multi-file torrent
-		for _, fileInfo := range mi.Info.Files {
-			mi.TotalLength += fileInfo.Length
+	if alRaw, ok := torrentMap["announce-list"].([]interface{}); ok {
+		mi.AnnounceList = make([][]string, len(alRaw))
+		for i, tierInterfaces := range alRaw {
+			if tierActual, tierOk := tierInterfaces.([]interface{}); tierOk {
+				mi.AnnounceList[i] = make([]string, len(tierActual))
+				for j, trackerInterface := range tierActual {
+					if trackerStr, okStr := trackerInterface.(string); okStr {
+						mi.AnnounceList[i][j] = trackerStr
+					}
+				}
+			}
 		}
 	}
-	if mi.TotalLength == 0 {
-		return nil, errors.New("metainfo: total length of files is zero")
+	if comment, ok := torrentMap["comment"].(string); ok {
+		mi.Comment = comment
+	}
+	if createdBy, ok := torrentMap["created by"].(string); ok {
+		mi.CreatedBy = createdBy
+	}
+	if creationDate, ok := torrentMap["creation date"].(int64); ok {
+		mi.CreationDate = creationDate
 	}
 
-	// Basic validation: number of pieces should match total length and piece length
-	expectedNumPieces := (mi.TotalLength + mi.Info.PieceLength - 1) / mi.Info.PieceLength
-	if int(expectedNumPieces) != numPieces {
-		return nil, errors.New("metainfo: number of pieces does not match total length and piece length")
+	// Get the 'info' dictionary
+	infoMapInterface, infoPresent := torrentMap["info"]
+	if !infoPresent {
+		return nil, errors.New("metainfo: 'info' dictionary missing")
+	}
+	infoMap, ok := infoMapInterface.(map[string]interface{})
+	if !ok {
+		return nil, errors.New("metainfo: 'info' is not a dictionary")
 	}
 
+	// Calculate InfoHash
+	var infoBuf bytes.Buffer
+	if err := gobencode.Encode(&infoBuf, infoMap); err != nil {
+		return nil, fmt.Errorf("metainfo: failed to bencode 'info' dictionary for hashing: %w", err)
+	}
+	h := sha1.New()
+	_, err = h.Write(infoBuf.Bytes())
+    if err != nil {
+        return nil, fmt.Errorf("metainfo: failed to write to sha1 hasher: %w", err)
+    }
+	copy(mi.InfoHash[:], h.Sum(nil))
+
+	// Populate mi.Info (InfoDict)
+	if pl, ok := infoMap["piece length"].(int64); ok {
+		if pl <= 0 { return nil, errors.New("metainfo: 'piece length' must be positive") }
+		mi.Info.PieceLength = pl
+	} else { return nil, errors.New("metainfo: 'piece length' missing or not an integer") }
+
+	if piecesStr, ok := infoMap["pieces"].(string); ok {
+		if len(piecesStr)%sha1.Size != 0 { return nil, fmt.Errorf("metainfo: 'pieces' length (%d) is not a multiple of %d", len(piecesStr), sha1.Size) }
+		mi.Info.Pieces = piecesStr
+	} else { return nil, errors.New("metainfo: 'pieces' missing or not a string") }
+
+	if name, ok := infoMap["name"].(string); ok {
+		mi.Info.Name = name
+	} else { return nil, errors.New("metainfo: 'name' missing or not a string") }
+    
+	if private, ok := infoMap["private"].(int64); ok {
+		mi.Info.Private = int(private)
+	}
+
+	if length, ok := infoMap["length"].(int64); ok {
+		if length < 0 { return nil, errors.New("metainfo: 'length' cannot be negative") }
+		mi.Info.Length = length
+		mi.TotalLength = length
+	} else if filesRaw, filesOk := infoMap["files"].([]interface{}); filesOk {
+		if len(filesRaw) == 0 { return nil, errors.New("metainfo: 'files' array is present but empty") }
+		mi.Info.Files = make([]FileInfo, len(filesRaw)) // Greška 'undefined: FileInfo' bi trebalo da nestane
+		var currentTotalLength int64
+		for i, fileRawInterface := range filesRaw {
+			fileMap, fileMapOk := fileRawInterface.(map[string]interface{})
+			if !fileMapOk { return nil, fmt.Errorf("metainfo: file entry %d in 'files' is not a dictionary", i) }
+			var fi FileInfo // I ovde
+			if l, lOk := fileMap["length"].(int64); lOk {
+				if l < 0 { return nil, fmt.Errorf("metainfo: file entry %d has negative length", i) }
+				fi.Length = l
+				currentTotalLength += l
+			} else { return nil, fmt.Errorf("metainfo: file entry %d 'length' missing or not an integer", i) }
+			if pRaw, pOk := fileMap["path"].([]interface{}); pOk {
+                if len(pRaw) == 0 { return nil, fmt.Errorf("metainfo: file entry %d 'path' array is empty", i) }
+				fi.Path = make([]string, len(pRaw))
+				for j, partInterface := range pRaw {
+					if partStr, partStrOk := partInterface.(string); partStrOk {
+						fi.Path[j] = partStr
+					} else { return nil, fmt.Errorf("metainfo: file entry %d path segment %d is not a string", i, j) }
+				}
+			} else { return nil, fmt.Errorf("metainfo: file entry %d 'path' missing or not a list", i) }
+            if md5sum, md5Ok := fileMap["md5sum"].(string); md5Ok { fi.Md5sum = md5sum }
+			mi.Info.Files[i] = fi
+		}
+		mi.TotalLength = currentTotalLength
+	} else { return nil, errors.New("metainfo: 'info' dictionary must contain either 'length' or 'files'") }
+
+	if mi.Info.PieceLength > 0 {
+		numPieces := len(mi.Info.Pieces) / sha1.Size
+		mi.PieceHashes = make([][20]byte, numPieces)
+		for i := 0; i < numPieces; i++ {
+			copy(mi.PieceHashes[i][:], []byte(mi.Info.Pieces[i*sha1.Size:(i+1)*sha1.Size]))
+		}
+		expectedNumPieces := (mi.TotalLength + mi.Info.PieceLength - 1) / mi.Info.PieceLength
+		if mi.TotalLength == 0 && numPieces == 0 && len(mi.Info.Pieces) == 0 {} else 
+        if int64(numPieces) != expectedNumPieces {
+			return nil, fmt.Errorf("metainfo: number of pieces from 'pieces' string (%d) does not match calculated expected number of pieces (%d)", numPieces, expectedNumPieces)
+		}
+	} else if len(mi.Info.Pieces) > 0 {
+        return nil, errors.New("metainfo: 'pieces' field is present but 'piece length' is zero or invalid")
+    }
 
 	return mi, nil
-}
-
-// MetaInfo predstavlja parsirane podatke iz .torrent fajla
-type MetaInfo struct {
-	Announce     string     // URL glavnog trackera
-	AnnounceList [][]string `bencode:"announce-list"` // Opciona lista backup trackera (lista listi stringova)
-	Comment      string     `bencode:"comment"`       // Opcioni komentar kreatora torrenta
-	CreatedBy    string     `bencode:"created by"`    // Opciono, ime programa koji je kreirao torrent
-	CreationDate int64      `bencode:"creation date"` // Opciono, Unix timestamp kreiranja
-
-	// 'Info' deo je ključan i sadrži informacije o fajlovima
-	// U .torrent fajlu je kao dictionary, ali ga mi čuvamo kao strukturu
-	Info InfoDict
-
-	// Ovi podaci se izračunavaju NAKON parsiranja 'Info' dela
-	// i ne čitaju se direktno iz bencode-a na ovom nivou
-	InfoHash    [20]byte   // SHA-1 hash bencode-ovanog 'Info' dictionary-ja
-	PieceHashes [][20]byte // Niz 20-bajtnih SHA-1 hasheva za svaki deo
-	TotalLength int64      // Ukupna veličina svih fajlova u torrentu
-}
-
-// InfoDict predstavlja "info" dictionary unutar .torrent fajla.
-// Ovaj dictionary je ono što se hashira da bi se dobio InfoHash.
-type InfoDict struct {
-	PieceLength int64  `bencode:"piece length"` // Veličina jednog dela u bajtovima
-	Pieces      string `bencode:"pieces"`       // String koji sadrži spojene 20-bajtne SHA-1 hasheve svih delova
-	Private     int    `bencode:"private"`      // Opciono, da li je torrent privatan (1 za da, 0 ili odsutno za ne)
-	Name        string `bencode:"name"`         // Predloženo ime za čuvanje (fajla ili direktorijuma)
-
-	// Za torrente sa jednim fajlom:
-	Length int64 `bencode:"length,omitempty"` // Veličina fajla u bajtovima (samo za single-file torrente)
-
-	// Za torrente sa više fajlova:
-	Files []FileInfo `bencode:"files,omitempty"` // Lista fajlova (samo za multi-file torrente)
-}
-
-// FileInfo opisuje jedan fajl unutar multi-file torrenta
-type FileInfo struct {
-	Length int64    `bencode:"length"`          // Veličina ovog fajla u bajtovima
-	Path   []string `bencode:"path"`            // Lista stringova koji predstavljaju putanju do fajla (npr. ["dir1", "dir2", "file.ext"])
-	Md5sum string   `bencode:"md5sum,omitempty"` // Opcioni MD5 hash fajla (retko se koristi)
 }


### PR DESCRIPTION
This pull request introduces core functionalities for the GoTorrent CLI client: a custom Bencode parser and the ability to communicate with HTTP/HTTPS trackers.

**Key Changes:**

*   **Custom Bencode Parser (`internal/gobencode`):**
    *   Implemented `Decode()` function for parsing Bencode encoded data (integers, strings, lists, dictionaries) into Go native types (`int64`, `string`, `[]interface{}`, `map[string]interface{}`).
    *   Implemented `Encode()` function for encoding Go native types into Bencode format. This includes sorting dictionary keys lexicographically as per the Bencode specification.
    *   Added comprehensive unit tests for both `Decode()` and `Encode()` functions, all of which are passing.

*   **Metainfo Parsing (`internal/metainfo`):**
    *   The `metainfo` package has been updated to use the new custom `gobencode` package.
    *   Correctly calculates the `InfoHash` by bencoding the `info` dictionary and applying SHA-1.
    *   Successfully parses `.torrent` file metadata.

*   **Tracker Communication (`internal/tracker` & `cmd/gottrent/main.go`):**
    *   Added functionality to generate a Peer ID.
    *   Implemented `TrackerRequest` and `TrackerResponse` structures.
    *   The client can now build and send "announce" requests to HTTP/HTTPS trackers specified in a `.torrent` file.
    *   Successfully parses Bencode responses from trackers to retrieve interval, seeder/leecher counts, and a list of peers.
    *   Skips UDP trackers for now, as UDP tracker protocol is not yet implemented.

**Testing:**
*   Unit tests for `gobencode` pass.
*   Successfully parsed a valid `.torrent` file (e.g., Ubuntu torrent) and received a peer list from its HTTP tracker.
*   Handled cases where tracklists contain UDP trackers or when HTTP trackers are unresponsive (timeout).

This PR lays a crucial foundation for peer-to-peer communication.